### PR TITLE
MintbaseSDK/buy: change "burn" to "buy"

### DIFF
--- a/mintbase-sdk-ref/packages/sdk/src/buy/README.md
+++ b/mintbase-sdk-ref/packages/sdk/src/buy/README.md
@@ -41,7 +41,7 @@ Example usage of buy method in a hypothetical React component:
 ```typescript
 import { useState } from 'react';
 import { useWallet } from '@mintbase-js/react';
-import { execute, burn, BuyArgs } from '@mintbase-js/sdk';
+import { execute, buy, BuyArgs } from '@mintbase-js/sdk';
 
 
 export const BuyComponent = ({ contractAddress, price, tokenId, affiliateAccount, marketId }:BuyArgs): JSX.Element => {
@@ -64,7 +64,7 @@ export const BuyComponent = ({ contractAddress, price, tokenId, affiliateAccount
   return (
     <div>
       <button onClick={handleBuy}>
-        Burn provided token array from {contractAddress}
+        Buy {tokenId} from {contractAddress}
       </button>
     </div>
   );


### PR DESCRIPTION
The code examples were written with the "burn" method, but meant to be using the "buy" method